### PR TITLE
Refactor: "거리 기반 조회 NativeQuery에서 JPQL로 변경"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+.gitmessage.txt
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,17 @@ dependencies {
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+//	// QueryDSL spatial
+//	// https://mvnrepository.com/artifact/com.querydsl/querydsl-sql-spatial
+//	implementation group: 'com.querydsl', name: 'querydsl-sql-spatial', version: '5.0.0'
+
+	// DB Spatial Type들 사용하기 위한 Library
+	// https://mvnrepository.com/artifact/org.locationtech.jts/jts-core
+	implementation group: 'org.locationtech.jts', name: 'jts-core', version: '1.19.0'
+
+	// https://mvnrepository.com/artifact/org.hibernate/hibernate-spatial
+	implementation group: 'org.hibernate', name: 'hibernate-spatial', version: '5.6.5.Final'
+
 	// p6spy
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.1'
 
@@ -110,10 +121,6 @@ dependencies {
 
 	// AWS S3
 	implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.2'
-
-	// 공간 데이터 => 안 해도 작동하길래 일단 빼둠
-	// https://mvnrepository.com/artifact/org.hibernate/hibernate-spatial
-//	implementation group: 'org.hibernate', name: 'hibernate-spatial', version: '5.6.5.Final', ext: 'pom'
 
 	// spring-boot-start-test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/ywphsm/ourneighbor/api/HashtagApiController.java
+++ b/src/main/java/ywphsm/ourneighbor/api/HashtagApiController.java
@@ -2,8 +2,6 @@ package ywphsm.ourneighbor.api;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.json.simple.parser.ParseException;
-import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
 import ywphsm.ourneighbor.domain.dto.hashtag.HashtagDTO;
 import ywphsm.ourneighbor.service.HashtagOfMenuService;

--- a/src/main/java/ywphsm/ourneighbor/api/MapSearchController.java
+++ b/src/main/java/ywphsm/ourneighbor/api/MapSearchController.java
@@ -2,6 +2,7 @@ package ywphsm.ourneighbor.api;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.locationtech.jts.io.ParseException;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -61,9 +62,9 @@ public class MapSearchController {
     }
 
     @GetMapping("/get-top5-categories")
-    public ResultClass<?> getTop5StoresByCategories(@RequestParam String categoryId,
+    public ResultClass<?> getTop5StoresByCategories(@RequestParam Long categoryId,
                                             @CookieValue(value = "lat", required = false) String myLat,
-                                            @CookieValue(value = "lon", required = false) String myLon) {
+                                            @CookieValue(value = "lon", required = false) String myLon) throws ParseException {
         double dist = 3;
 
         List<Store> findStores = storeService.getTop5ByCategories(categoryId, dist,

--- a/src/main/java/ywphsm/ourneighbor/api/StoreApiController.java
+++ b/src/main/java/ywphsm/ourneighbor/api/StoreApiController.java
@@ -2,6 +2,7 @@ package ywphsm.ourneighbor.api;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.locationtech.jts.io.ParseException;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -30,7 +31,7 @@ public class StoreApiController {
 
     @GetMapping("/get-images")
     public List<List<String>> getImages(@CookieValue(value = "lat", required = false, defaultValue = "") String lat,
-                                        @CookieValue(value = "lon", required = false, defaultValue = "") String lon) {
+                                        @CookieValue(value = "lon", required = false, defaultValue = "") String lon) throws ParseException {
 
         List<CategoryDTO.Simple> rootCategoryList = categoryService.findByDepth(1L);
 
@@ -41,7 +42,7 @@ public class StoreApiController {
         if (lat != null && lon != null) {
             for (CategoryDTO.Simple simple : rootCategoryList) {
                 categoryImageList.add(storeService.getTop5ImageByCategories(
-                        (simple.getCategoryId().toString()), dist, Double.parseDouble(lat), Double.parseDouble(lon)));
+                        (simple.getCategoryId()), dist, Double.parseDouble(lat), Double.parseDouble(lon)));
             }
         }
 

--- a/src/main/java/ywphsm/ourneighbor/controller/HomeController.java
+++ b/src/main/java/ywphsm/ourneighbor/controller/HomeController.java
@@ -8,9 +8,7 @@ import org.springframework.web.bind.annotation.*;
 
 import ywphsm.ourneighbor.domain.dto.category.CategoryDTO;
 import ywphsm.ourneighbor.domain.search.StoreSearchCond;
-import ywphsm.ourneighbor.domain.store.Store;
 import ywphsm.ourneighbor.service.CategoryService;
-import ywphsm.ourneighbor.service.StoreService;
 
 import java.util.List;
 

--- a/src/main/java/ywphsm/ourneighbor/domain/store/Store.java
+++ b/src/main/java/ywphsm/ourneighbor/domain/store/Store.java
@@ -2,7 +2,8 @@ package ywphsm.ourneighbor.domain.store;
 
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
-import ywphsm.ourneighbor.config.AuditingConfig;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Point;
 import ywphsm.ourneighbor.domain.*;
 import ywphsm.ourneighbor.domain.category.CategoryOfStore;
 import ywphsm.ourneighbor.domain.embedded.Address;
@@ -63,6 +64,13 @@ public class Store extends BaseEntity {
 
     private String parkDetail;
 
+//    @Column(columnDefinition = "point")
+//    private Point location;
+//
+//    @Column(columnDefinition = "polygon")
+//    private LineString route;
+
+
     /*
         임베디드 타입
      */
@@ -71,7 +79,6 @@ public class Store extends BaseEntity {
 
     @Embedded
     private BusinessTime businessTime;
-
 
     /*
         JPA 연관 관계 매핑

--- a/src/main/java/ywphsm/ourneighbor/repository/store/StoreRepository.java
+++ b/src/main/java/ywphsm/ourneighbor/repository/store/StoreRepository.java
@@ -1,6 +1,9 @@
 package ywphsm.ourneighbor.repository.store;
 
+import org.locationtech.jts.geom.Geometry;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import ywphsm.ourneighbor.domain.store.Store;
 
 import java.util.List;
@@ -8,4 +11,7 @@ import java.util.List;
 public interface StoreRepository extends JpaRepository<Store, Long>, StoreRepositoryCustom {
 
     List<Store> findByName(String name);
+
+    @Query(value = "SELECT s FROM Store s WHERE within(:point, :bounds) = true")
+    List<Store> findAllWithin(@Param("point") Geometry point, @Param("bounds") Geometry bounds);
 }

--- a/src/main/java/ywphsm/ourneighbor/repository/store/StoreRepositoryCustom.java
+++ b/src/main/java/ywphsm/ourneighbor/repository/store/StoreRepositoryCustom.java
@@ -1,5 +1,6 @@
 package ywphsm.ourneighbor.repository.store;
 
+import org.locationtech.jts.io.ParseException;
 import ywphsm.ourneighbor.domain.search.StoreSearchCond;
 import ywphsm.ourneighbor.domain.store.Store;
 
@@ -13,5 +14,5 @@ public interface StoreRepositoryCustom {
 
     List<Store> searchByCategory(Long categoryId);
 
-    List<Store> getTop5ByCategories(String categoryId, double dist, double lat, double lon);
+    List<Store> getTop5ByCategories(Long categoryId, double dist, double lat, double lon) throws ParseException;
 }

--- a/src/main/java/ywphsm/ourneighbor/service/StoreService.java
+++ b/src/main/java/ywphsm/ourneighbor/service/StoreService.java
@@ -2,6 +2,7 @@ package ywphsm.ourneighbor.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.locationtech.jts.io.ParseException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -230,11 +231,11 @@ public class StoreService {
 
     // 참고
     // https://wooody92.github.io/project/JPA%EC%99%80-MySQL%EB%A1%9C-%EC%9C%84%EC%B9%98-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EB%8B%A4%EB%A3%A8%EA%B8%B0/
-    public List<Store> getTop5ByCategories(String categoryId, double dist, double lat, double lon) {
+    public List<Store> getTop5ByCategories(Long categoryId, double dist, double lat, double lon) throws ParseException {
         return storeRepository.getTop5ByCategories(categoryId, dist, lat, lon);
     }
 
-    public List<String> getTop5ImageByCategories(String categoryId, double dist, double lat, double lon) {
+    public List<String> getTop5ImageByCategories(Long categoryId, double dist, double lat, double lon) throws ParseException {
         List<Store> top5 = storeRepository.getTop5ByCategories(categoryId, dist, lat, lon);
         List<String> top5UrlList = new ArrayList<>();
 

--- a/src/main/resources/static/js/weather.js
+++ b/src/main/resources/static/js/weather.js
@@ -107,7 +107,6 @@ var main = {
     },
 
     setWeatherInfoInEl: function(skyStatus, currentTmp, currentPop, pm10Value) {
-        console.log("이놈 호출")
         const _skyStatus = document.getElementById("sky-status");
         const _tmp = document.getElementById("tmp");
         const _pop = document.getElementById("pop");

--- a/src/main/resources/templates/store/detail.html
+++ b/src/main/resources/templates/store/detail.html
@@ -271,7 +271,7 @@
                                 </div>
                             </div>
                             <div class="px-0 col-lg-6 col-sm-12 d-flex border border-secondary">
-                                <div class="menu-detail border-end border-secondary col-4">
+                                <div class="menu-detail border-end border-secondary col-5">
                                     <div class="menu-detail-img mb-2">
                                         <img th:src="${menu.uploadImgUrl}" width="100%" height="222px" alt="메뉴 사진">
                                     </div>
@@ -287,7 +287,7 @@
                                            th:text="|${menu.price}원|"></p>
                                     </div>
                                 </div>
-                                <div class="menu-hashtag col-8 row row-cols-md-3 row-cols-2 ">
+                                <div class="menu-hashtag col-7 row row-cols-md-3 row-cols-2">
                                     <th:block th:each="hashtag: ${menu.hashtagOfMenuDTOList}">
                                         <div class="my-auto text-center col text-nowrap"
                                              th:text="${hashtag.hashtagName}">해쉬태그


### PR DESCRIPTION
거리 기반 조회 로직 getTop5ByCategories의 쿼리를 NatvieQuery에서 JPQL로 변경
NativeQuery 사용 시, DB 마이그레이션을 할 경우 DB 마다의 차이로 인한
쿼리문 미지원이 발생할 수 있음
이 경우, JPQL을 사용하면 쿼리문의 수정을 고려하지 않아도 됨 (즉, JPA의
장점 중 하나인 벤더 독립성을 지킬 수 있음)