### PR TITLE
Fix: 매장 관리자가 해쉬태그 직접 등록 시, 기존에 존재하는 해쉬태그인 경우 등록에 실패하는 버그 해결

### DIFF
--- a/src/main/java/ywphsm/ourneighbor/api/MenuApiController.java
+++ b/src/main/java/ywphsm/ourneighbor/api/MenuApiController.java
@@ -23,6 +23,7 @@ import java.net.MalformedURLException;
 public class MenuApiController {
 
     private final MenuService menuService;
+
     private final StoreService storeService;
 
     private final FileStore fileStore;

--- a/src/main/java/ywphsm/ourneighbor/service/HashtagService.java
+++ b/src/main/java/ywphsm/ourneighbor/service/HashtagService.java
@@ -48,12 +48,14 @@ public class HashtagService {
         if (!duplicateCheck) {
             newHashtag = save(dto);
 
-            linkHashtagAndStore(newHashtag, findStore);
-
-            return newHashtag.getId();
         } else {
-            return -1L;
+            newHashtag = hashtagRepository.findByName(dto.getName());
+
         }
+
+        linkHashtagAndStore(newHashtag, findStore);
+
+        return newHashtag.getId();
     }
 
     @Transactional

--- a/src/main/resources/static/js/recommend_post.js
+++ b/src/main/resources/static/js/recommend_post.js
@@ -163,8 +163,6 @@ let main = {
 
                 i++;
             }
-
-
         }).catch((error) => {
             console.log(error);
         });


### PR DESCRIPTION
hashtag 직접 등록 시, 존재하던 hashtag인 경우 hashtag 저장을 하지 않더라도 store와 hashtag 간의 연결은 이루어지게 변경. (즉, 새 hashtag가 생성되는 것이 아니라 기존의 hashtag를 가져와 store와 연결만 해줌. 기존
코드는 hashtag가 존재하면 -1을 반환하고, 중복으로 인한 경고창만 띄웠음)