### PR TITLE
Fix: "매장 등록 시, 해쉬태그 연동 모달에서 엔터키 기능 버그 해결"

### DIFF
--- a/src/main/resources/static/js/hashtag.js
+++ b/src/main/resources/static/js/hashtag.js
@@ -30,6 +30,19 @@ var main = {
                 this.saveHashtag();
             });
         }
+
+        const hashtagInput = document.getElementById("hashtag");
+
+        // 엔터키 입력하면 saveHashtag() 동작
+        hashtagInput.addEventListener("keydown", (e) => {
+            if (hashtagInput.value !== "") {
+                if (e.isComposing === false && e.code === "Enter") { // 한글 입력 시 이벤트 두번 발생 방지
+                    e.preventDefault();
+                    this.saveHashtag();
+                }
+            }
+        });
+
     },
 
     createHashtagInput: function (menuId) {
@@ -53,24 +66,24 @@ var main = {
             // Chainable event listeners
             tagify.on("input", onInput);
 
-            var mockAjax = (function mockAjax(){
+            var mockAjax = (function mockAjax() {
                 var timeout;
-                return function(duration){
+                return function (duration) {
                     clearTimeout(timeout);
-                    return new Promise(function(resolve, reject){
+                    return new Promise(function (resolve, reject) {
                         timeout = setTimeout(resolve, duration || 700, whitelist)
                     })
                 }
             })();
 
             // on character(s) added/removed (user is typing/deleting)
-            function onInput(e){
+            function onInput(e) {
                 tagify.settings.whitelist.length = 0;                   // reset current whitelist
                 tagify.loading(true).dropdown.hide.call(tagify); // show the loader animation
 
                 // get new whitelist from a delayed mocked request (Promise)
                 mockAjax()
-                    .then(function(result){
+                    .then(function (result) {
                         // replace tagify "whitelist" array values with new values
                         // and add back the ones already choses as Tags
                         tagify.settings.whitelist.push(...result, ...tagify.value)

--- a/src/main/resources/static/js/map.js
+++ b/src/main/resources/static/js/map.js
@@ -75,14 +75,18 @@ var main = {
     setSearchKeywordEvent: function (map) {
         let prevKeyword = sessionStorage.getItem("keyword");
 
-        // 엔터키 입력하면 searchByKeyword 동작
+        /*
+            엔터키 입력하면 searchByKeyword 동작
+         */
         document.getElementById("keyword").addEventListener("keydown", (e) => {
             if (e.isComposing === false && e.code === "Enter") { // 한글 입력 시 이벤트 두번 발생 방지
                 this.searchByKeyword(prevKeyword, map);
             }
         });
 
-        // 클릭 이벤트 시 searchByKeyword 동작
+        /*
+            클릭 이벤트 시 searchByKeyword 동작
+         */
         document.getElementById("searchBtn").addEventListener("click", () => {
             this.searchByKeyword(prevKeyword, map);
         });

--- a/src/main/resources/templates/hashtag/list.html
+++ b/src/main/resources/templates/hashtag/list.html
@@ -68,8 +68,8 @@
     </div>
 </section>
 <!-- Modal -->
-<div class="modal fade" id="edit-hashtag-modal" data-bs-keyboard="false" tabindex="-1"
-     aria-labelledby="edit-hashtag-modal-label" aria-hidden="true">
+<div class="modal fade" id="edit-hashtag-modal" data-bs-keyboard="true" data-bs-config='{"backdrop": "static"}'
+     tabindex="-1" aria-labelledby="edit-hashtag-modal-label" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
             <form id="hashtag-form">
@@ -80,7 +80,9 @@
                 </div>
                 <div class="modal-body">
                     <div class="form-group">
-                        <span class="mb-2">해쉬태그 추가</span>
+                        <label for="hashtag">
+                            <span class="mb-2">해쉬태그 추가</span>
+                        </label>
                         <div class="mb-3">
                             <input id="hashtag" name="name" style="width: 100%" autofocus>
                         </div>

--- a/src/main/resources/templates/store/detail.html
+++ b/src/main/resources/templates/store/detail.html
@@ -312,7 +312,7 @@
                                 </div>
                             </div>
                             <!-- Modal -->
-                            <div class="modal fade" id="menu-modal" data-bs-keyboard="false" tabindex="-1"
+                            <div class="modal fade" id="menu-modal" data-bs-keyboard="true" tabindex="-1"
                                  aria-labelledby="edit-image-modal-label" aria-hidden="true">
                                 <div class="modal-dialog modal-dialog-centered">
                                     <div id="modal-content" class="modal-content">


### PR DESCRIPTION
부트스트랩 모달 기능의 한계로 엔터키를 입력하면 페이지가 새로고침 됨.
모달 내부의 input 태그에 값이 있는 경우에 preventDefault로 이벤트를 막고 엔터키를 'keydown'할 시 saveHashtag()가 수행되게 변경.
235