### PR TITLE
Fix: "매장 등록, 수정 시 Validation 이전에 로딩 화면 넘어가는 버그 수정"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -180,9 +180,9 @@ dependencies {
 	testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
-tasks.named('test') {
-   useJUnitPlatform()
-}
+//tasks.named('test') {
+//   useJUnitPlatform()
+//}
 
 /*
 	Querydsl 추가, 자동 생성된 Q클래스 gradle clean으로 제거

--- a/src/main/java/ywphsm/ourneighbor/service/MenuService.java
+++ b/src/main/java/ywphsm/ourneighbor/service/MenuService.java
@@ -73,10 +73,6 @@ public class MenuService {
 
     @Transactional
     public Long update(Long storeId, MenuDTO.Update dto) throws IOException, ParseException {
-
-        log.info("dto={}", dto);
-        log.info("file={}", dto.getFile().getOriginalFilename());
-
         Menu entity = dto.toEntity();
 
         Menu menu = menuRepository.findById(dto.getId()).orElseThrow(

--- a/src/main/resources/static/js/menu.js
+++ b/src/main/resources/static/js/menu.js
@@ -55,8 +55,6 @@ var main = {
     },
 
     check: function () {
-        mask.loadingWithMask();
-
         const name = document.getElementById("name");
         const price = document.getElementById("price");
         const type = document.getElementsByName("type");
@@ -66,8 +64,6 @@ var main = {
         const priceValid = document.getElementById("menu-price-valid");
         const typeValid = document.getElementById("menu-type-valid");
         const featureValid = document.getElementById("menu-feature-valid");
-
-        const storeId = document.getElementById("storeId").value;
 
         name.classList.remove("valid-custom");
         price.classList.remove("valid-custom");
@@ -95,8 +91,12 @@ var main = {
             }
         }
 
+        const storeId = document.getElementById("storeId").value;
+
         if (name.value !== "" && storeId !== "" && price.value !== ""
             && typeCheck === true && featureCheck === true && numRegCheck) {
+            mask.loadingWithMask();
+
             axios({
                 method: "get",
                 url: "/seller/menu/check",
@@ -160,23 +160,10 @@ var main = {
     },
 
     save: function () {
-        mask.loadingWithMask();
         const menuForm = document.getElementById("menu-add-form");
-
         const formData = new FormData(menuForm);
 
         this.createDefaultImg(formData);
-
-        // FormData의 key 확인
-        for (let key of formData.keys()) {
-            console.log(key);
-        }
-
-        // FormData의 value 확인
-        for (let value of formData.values()) {
-            console.log(value);
-        }
-
 
         axios({
             headers: {
@@ -197,31 +184,59 @@ var main = {
     },
 
     update: function (btnId) {
-        mask.loadingWithMask();
         const id = btnId.substring(13);
 
-        const menuForm = document.getElementById("menu-edit-form" + id);
-        const storeIdVal = document.getElementById("storeId").value;
+        const menuUpdateFormEls = {
+            name: document.getElementById("menu-edit-name" + id),
+            price: document.getElementById("menu-edit-price" + id)
+        }
 
-        let formData = new FormData(menuForm);
-        this.createDefaultImg(formData);
+        const menuUpdateFormValids = {
+            nameValid: document.getElementById("menu-edit-name" + id + "-valid"),
+            priceValid: document.getElementById("menu-edit-price" + id + "-valid")
+        }
 
-        axios({
-            headers: {
-                "Content-Type": "multipart/form-data",
-                "Access-Control-Allow_Origin": "*"
-            },
-            method: "put",
-            url: "/seller/menu/" + storeIdVal,
-            data: formData
-        }).then((resp) => {
-            alert("메뉴 정보 수정이 완료됐습니다.");
-            window.location.reload();
-            mask.closeMask();
-        }).catch((error) => {
-            console.log(error);
-            mask.closeMask();
-        })
+        for (const el in menuUpdateFormEls) {
+            menuUpdateFormEls[el].classList.remove("valid-custom");
+        }
+
+        for (const el in menuUpdateFormValids) {
+            validation.removeValidation(menuUpdateFormValids[el]);
+        }
+
+        if (menuUpdateFormEls["name"].value !== "" && menuUpdateFormEls["price"].value !== "") {
+            const menuForm = document.getElementById("menu-edit-form" + id);
+            const storeIdVal = document.getElementById("storeId").value;
+
+            let formData = new FormData(menuForm);
+            this.createDefaultImg(formData);
+
+            mask.loadingWithMask();
+
+            axios({
+                headers: {
+                    "Content-Type": "multipart/form-data",
+                    "Access-Control-Allow_Origin": "*"
+                },
+                method: "put",
+                url: "/seller/menu/" + storeIdVal,
+                data: formData
+            }).then((resp) => {
+                alert("메뉴 정보 수정이 완료됐습니다.");
+                window.location.reload();
+                mask.closeMask();
+            }).catch((error) => {
+                console.log(error);
+                mask.closeMask();
+            })
+        }
+
+        for (const el in menuUpdateFormEls) {
+            if (menuUpdateFormEls[el].value === "") {
+                menuUpdateFormEls[el].classList.add("valid-custom");
+                validation.addValidation(menuUpdateFormValids[el + "Valid"], "필수값입니다.");
+            }
+        }
     },
 
     delete: function (btnId) {
@@ -229,8 +244,6 @@ var main = {
         const id = btnId.substring(15);
         const storeId = document.getElementById("storeId").value;
         const menuId = document.getElementById("menuId" + id).value;
-
-        console.log(menuId);
 
         axios({
             method: "delete",

--- a/src/main/resources/static/js/store.js
+++ b/src/main/resources/static/js/store.js
@@ -5,7 +5,6 @@ var main = {
     init: function () {
         let _this = this;
 
-        // mask.loadingWithMask();
         if (document.getElementById("category-main")) {
             const categoryMain = document.getElementById("category-main").value;
             const categoryMid = document.getElementById("category-mid").value;
@@ -14,7 +13,7 @@ var main = {
             categoryList.push(categoryMain);
             categoryList.push(categoryMid);
             categoryList.push(categorySub);
-            console.log("categoryList = ", categoryList)
+
             _this.getCategories(categoryList);
         } else {
             _this.getCategories();
@@ -62,10 +61,7 @@ var main = {
     },
 
     save: function () {
-        mask.loadingWithMask();
-
-        // input 태그
-        const els = {
+        const storeFormEls = {
             name: document.getElementById("name"),
             zipcode: document.getElementById("zipcode"),
             roadAddr: document.getElementById("roadAddr"),
@@ -75,7 +71,7 @@ var main = {
         }
 
         // input 아래의 validation을 담을 div 태그
-        const valids = {
+        const storeFormValids = {
             nameValid: document.getElementById("store-name-valid"),
             zipcodeValid: document.getElementById("store-zipcode-valid"),
             roadAddrValid: document.getElementById("store-roadAddr-valid"),
@@ -87,26 +83,28 @@ var main = {
         const cateValid = document.getElementById("store-category-valid");
         const mainCateVal = document.getElementById("main-cate").options
             [document.getElementById("main-cate").selectedIndex].value;
-        const storeForm = document.getElementById("store-add-form");
 
-        const formData = new FormData(storeForm);
-
-        for (const el in els) {
-            els[el].classList.remove("valid-custom");
+        for (const el in storeFormEls) {
+            storeFormEls[el].classList.remove("valid-custom");
         }
 
-        for (const v in valids) {
-            validation.removeValidation(valids[v]);
+        for (const v in storeFormValids) {
+            validation.removeValidation(storeFormValids[v]);
         }
 
         validation.removeValidation(cateValid);
 
         this.categoryLayerEl.main.classList.remove("input-error-border");
 
-        if (els["name"].value !== "" && els["zipcode"].value !== ""
-            && els["roadAddr"].value !== "" && els["numberAddr"].value !== ""
-            && els["openingTime"].value !== "" && els["closingTime"].value !== ""
+        if (storeFormEls["name"].value !== "" && storeFormEls["zipcode"].value !== ""
+            && storeFormEls["roadAddr"].value !== "" && storeFormEls["numberAddr"].value !== ""
+            && storeFormEls["openingTime"].value !== "" && storeFormEls["closingTime"].value !== ""
             && mainCateVal !== "") {
+
+            const storeForm = document.getElementById("store-add-form");
+            const formData = new FormData(storeForm);
+
+            mask.loadingWithMask();
 
             axios({
                 method: "post",
@@ -123,10 +121,10 @@ var main = {
             });
         }
 
-        for (const el in els) {
-            if (els[el].value === "") {
-                els[el].classList.add("valid-custom");
-                validation.addValidation(valids[el + "Valid"], "위의 값들은 필수입니다.");
+        for (const el in storeFormEls) {
+            if (storeFormEls[el].value === "") {
+                storeFormEls[el].classList.add("valid-custom");
+                validation.addValidation(storeFormValids[el + "Valid"], "위의 값들은 필수입니다.");
             }
         }
 
@@ -162,10 +160,6 @@ var main = {
         const cateValid = document.getElementById("store-category-valid");
         const mainCateVal = document.getElementById("main-cate").options
             [document.getElementById("main-cate").selectedIndex].value;
-        const storeForm = document.getElementById("store-edit-form");
-
-        const formData = new FormData(storeForm);
-        const storeIdVal = document.getElementById("storeId").value;
 
         for (const el in els) {
             els[el].classList.remove("valid-custom");
@@ -183,6 +177,11 @@ var main = {
             && els["roadAddr"].value !== "" && els["numberAddr"].value !== ""
             && els["openingTime"].value !== "" && els["closingTime"].value !== ""
             && mainCateVal !== "") {
+
+            const storeForm = document.getElementById("store-edit-form");
+            const formData = new FormData(storeForm);
+            const storeIdVal = document.getElementById("storeId").value;
+
 
             axios({
                 method: "put",

--- a/src/main/resources/templates/menu/edit_form.html
+++ b/src/main/resources/templates/menu/edit_form.html
@@ -45,6 +45,8 @@
                                                 <input class="form-control" th:id="|menu-edit-name${i.index+1}|"
                                                        name="name"
                                                        th:value="${menu.name}"/>
+                                                <div th:id="|menu-edit-name${i.index+1}-valid|" class="my-1 valid-custom">
+                                                </div>
                                             </div>
                                         </div>
                                         <div class="form-group">
@@ -55,6 +57,8 @@
                                                 <input class="form-control" th:id="|menu-edit-price${i.index+1}|"
                                                        name="price"
                                                        th:value="${menu.price}"/>
+                                                <div th:id="|menu-edit-price${i.index+1}-valid|" class="my-1 valid-custom">
+                                                </div>
                                             </div>
                                         </div>
                                         <div class="form-group">
@@ -65,7 +69,6 @@
                                                 <input class="form-control" th:id="|menu-edit-dcPrice${i.index+1}|"
                                                        name="discountPrice"
                                                        th:value="${menu.discountPrice}"/>
-                                                <span></span>
                                             </div>
                                         </div>
                                         <div class="form-group">

--- a/src/test/java/ywphsm/ourneighbor/api/ProfileControllerUnitTest.java
+++ b/src/test/java/ywphsm/ourneighbor/api/ProfileControllerUnitTest.java
@@ -11,7 +11,6 @@ class ProfileControllerUnitTest {
 
     @Test
     void getRealProfile() {
-
         String expectedProfile = "real";
         MockEnvironment env = new MockEnvironment();
 
@@ -28,7 +27,6 @@ class ProfileControllerUnitTest {
 
     @Test
     void noRealProfile() {
-
         String expectedProfile = "oauth";
         MockEnvironment env = new MockEnvironment();
 
@@ -39,7 +37,6 @@ class ProfileControllerUnitTest {
 
         String profile = controller.profile();
 
-        // 첫번째 profile인 oauth가 조회됨
         assertThat(profile).isEqualTo(expectedProfile);
     }
 
@@ -54,5 +51,4 @@ class ProfileControllerUnitTest {
 
         assertThat(profile).isEqualTo(expectedProfile);
     }
-
 }

--- a/src/test/java/ywphsm/ourneighbor/spatial/GeolatteTest.java
+++ b/src/test/java/ywphsm/ourneighbor/spatial/GeolatteTest.java
@@ -57,10 +57,4 @@ public class GeolatteTest {
 
         assertThat(refineDist).isEqualTo(3);
     }
-
-    @Test
-    @DisplayName("거리")
-    void test() {
-
-    }
 }

--- a/src/test/java/ywphsm/ourneighbor/spatial/JTSTest.java
+++ b/src/test/java/ywphsm/ourneighbor/spatial/JTSTest.java
@@ -27,7 +27,7 @@ class JTSTest {
 
     @Test
     @DisplayName("WKT 읽기")
-    void wktReader_test() throws ParseException {
+    void wktReaderTest() throws ParseException {
         String pointFormat = String.format("POINT(%f %f)", 35.1710366410643, 129.175759994618);
         String lineStringFormat = String.format("LINESTRING(%f %f, %f %f)", 35.182416023937336, 129.20790463400292, 35.14426110121965, 129.16123271344156);
         String polygonFormat = String.format("POLYGON((%f %f, %f %f, %f %f))", 35.182416023937336, 129.20790463400292, 35.14426110121965, 129.16123271344156, 35.182416023937336, 129.20790463400292);


### PR DESCRIPTION
매장 등록, 수정으 ㅣ경우 로딩화면이 먼저 넘어가고 뒤에 Validation이
수행됨. 이로 인해 기존까지 데이터를 넣지 못한 채로 로딩화면에 갇혀버렸음. Validation 순서를 변경하여 이를 해결 완료.
Issue Number: #250