### PR TITLE
Fix: "기본 이미지가 등록된 메뉴 삭제 시, S3 기본 이미지가 삭제되어

### DIFF
--- a/src/main/java/ywphsm/ourneighbor/domain/file/AwsS3FileStore.java
+++ b/src/main/java/ywphsm/ourneighbor/domain/file/AwsS3FileStore.java
@@ -77,6 +77,12 @@ public class AwsS3FileStore {
     }
 
     public void deleteFile(String storedFileName) {
+        final String defaultImgName ="defaultImg.png";
+        if (storedFileName.equals(defaultImgName)) {
+            log.info("기본 이미지는 삭제하지 않습니다.");
+            return;
+        }
+
         try {
             deleteFileInS3(storedFileName);
             log.info("s3 파일 삭제를 완료했습니다. S3 저장명={}", storedFileName);

--- a/src/main/java/ywphsm/ourneighbor/service/MenuService.java
+++ b/src/main/java/ywphsm/ourneighbor/service/MenuService.java
@@ -128,7 +128,8 @@ public class MenuService {
         }
 
         if (dto.getFile() != null) {
-            
+            log.info("dto={}", dto.getStoredFileName());
+
             /*
                 기존 메뉴 이미지 삭제
              */


### PR DESCRIPTION
버리는 버그 수정"
기본 이미지가 포함된 메뉴, 리뷰 등을 삭제하는 경우에 S3에 올려둔 defaultImg.png가 삭제되는 현상 발견. 
defaultImg.png로 storedFileName이 들어오는 경우 awsS3FileStore.deleteFile 메소드가 동작하지 않게 구현을 수정하여 해결