### PR TITLE
Fix: "미세먼지 농도 조회 실패 시 발생하는 버그 수정"

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -170,7 +170,15 @@ var main = {
             let currentTmp = resp.data.tmp;
             let currentPop = resp.data.pop;
             let currentPcp = resp.data.pcp;
-            let pm10Value = resp.data.pm10Value;
+            let pm10Value;
+
+            console.log(resp.data.pm10Value);
+
+            if (resp.data.pm10Value === "-") {
+                pm10Value = 50;
+            } else {
+                pm10Value = resp.data.pm10Value;
+            }
 
             cookie.setCookie("skyStatus", skyStatus, 1);
             cookie.setCookie("tmp", currentTmp, 1);

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -9,7 +9,6 @@
 </style>
 <body id="main-body" class="bg-default">
 <nav th:replace="layout/navbar :: common_navbar"></nav>
-<!--    div class="overlay"는 상위 section id="top"의 위치, 크기와 동일 => position을 relative로 설정-->
 <section class="main-title" style="height: 70vh">
     <div class="container-xxl align-self-center" style="height: 100%; position: relative">
         <div class="row align-items-center mt-3" style="height: 100%">


### PR DESCRIPTION
미세 먼지 농도를 받아오는 API가 먹통인 경우, 수치가 아닌 - 문자가
들어온다. 이로 인해 NumberFormatException이 발생하는데 이 경우 일단
미세먼지 농도가 50인 경우로 처리하게끔 수정하였음.