### PR TITLE
Fix: "HTML meta 태그 정리"

### DIFF
--- a/src/main/resources/templates/layout/header.html
+++ b/src/main/resources/templates/layout/header.html
@@ -2,7 +2,8 @@
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head th:fragment="common_header(title, style)">
     <meta name="viewport"
-          content="width=device-width initial-scale=1.0 text/html; charset=UTF-8"
+          charset="UTF-8"
+          content="width=device-width initial-scale=1.0"
           http-equiv="Content-Type">
 
     <meta name="description"


### PR DESCRIPTION
기존 meta 태그 구분자를 잘못 입력하여 정상적으로 동작하지 않았기에 이를 수정함.