### PR TITLE
Feature: "QueryDSL에서 Groupby 성능 최적화를 위한 OrderByNull 구현"

### DIFF
--- a/src/main/java/ywphsm/ourneighbor/repository/OrderByNull.java
+++ b/src/main/java/ywphsm/ourneighbor/repository/OrderByNull.java
@@ -1,0 +1,18 @@
+package ywphsm.ourneighbor.repository;
+
+import com.querydsl.core.types.NullExpression;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+
+/*
+    참고 블로그
+    https://jojoldu.tistory.com/477
+ */
+public class OrderByNull extends OrderSpecifier {
+
+    public static final OrderByNull DEFAULT = new OrderByNull();
+
+    private OrderByNull() {
+        super(Order.ASC, NullExpression.DEFAULT, NullHandling.Default);
+    }
+}

--- a/src/main/java/ywphsm/ourneighbor/repository/store/StoreRepositoryImpl.java
+++ b/src/main/java/ywphsm/ourneighbor/repository/store/StoreRepositoryImpl.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.*;
 import ywphsm.ourneighbor.domain.dto.store.days.DaysOfStoreDTO;
 import ywphsm.ourneighbor.domain.store.Store;
 import ywphsm.ourneighbor.domain.store.days.QDaysOfStore;
+import ywphsm.ourneighbor.repository.OrderByNull;
 import ywphsm.ourneighbor.repository.store.dto.SimpleSearchStoreDTO;
 
 import java.util.List;
@@ -94,6 +95,7 @@ public class StoreRepositoryImpl implements StoreRepositoryCustom {
                 .where(builder)
                 .where(stContains(polygon), stDistance(polygon).loe(3))
                 .groupBy(store.name)
+                .orderBy(OrderByNull.DEFAULT)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();


### PR DESCRIPTION
Grouby를 사용하면 자동으로 정렬이 수행되는데, 지금 기능에 정렬은 필요없음. 
추후에 정렬 기준을 도입하기 전까지 최적화를 위하여 OrderByNull을 별도로 구현하여 정렬이 수행되지 않게 만듬.