### PR TITLE
Fix: "대표 이미지가 없는 매장 삭제 시 발생하는 버그 수정"

### DIFF
--- a/src/main/java/ywphsm/ourneighbor/service/store/StoreService.java
+++ b/src/main/java/ywphsm/ourneighbor/service/store/StoreService.java
@@ -212,7 +212,7 @@ public class StoreService {
         List<MemberOfStore> memberOfStoreList = store.getMemberOfStoreList();
         memberOfStoreRepository.deleteAll(memberOfStoreList);
 
-        if ((store.getFile().getStoredFileName() != null)) {
+        if ((store.getFile() != null)) {
             awsS3FileStore.deleteFile(store.getFile().getStoredFileName());
         }
 

--- a/src/main/resources/templates/layout/header.html
+++ b/src/main/resources/templates/layout/header.html
@@ -9,7 +9,7 @@
     <meta name="description"
           content="현재 위치하는 주변의 핫플레이스를 기호와 날씨에 맞게 추천해드립니다.">
 
-    <title th:replace="${title}">우리 동네</title>
+    <title th:replace="${title}">우리동네</title>
     <style th:replace="${style}">
 
     </style>


### PR DESCRIPTION
대표 이미지가 없는 경우 이미지 삭제 로직의 검증이 이미지 존재 여부가
아닌 이미지 이름의 존재 여부로 설정돼있어서 발생한 버그.
이를 이미지 자체의 존재 여부로 검증 레벨을 변경하여 해결 완료.
Issue Number: #320