### PR TITLE
Fix: "폰트의 특수문자 미지원으로 인한 비밀번호 기호 표현 장애 버그 수정"

### DIFF
--- a/src/main/resources/static/css/app.css
+++ b/src/main/resources/static/css/app.css
@@ -8,6 +8,12 @@
     src: url("../font/Cafe24SsurroundAir.woff") format("woff");
 }
 
+
+@font-face {
+    font-family: "s-core";
+    src: url("../font/SCDream4.woff") format("woff");
+}
+
 /* Global */
 :root {
     --blue: #5e72e4;
@@ -58,9 +64,13 @@ body {
     background-color: #ffffff;
 }
 
-.thin{
+.thin {
     font-family: "Cafe24SsurroundAir", serif;
     font-weight: 700;
+}
+
+.password {
+    font-family: "s-core", serif;
 }
 
 input[type=radio] {

--- a/src/main/resources/templates/member/login_form.html
+++ b/src/main/resources/templates/member/login_form.html
@@ -63,7 +63,7 @@
                                         <span class="input-group-text"><i
                                                 class="ni ni-lock-circle-open"></i></span>
                                     </div>
-                                    <input class="form-control" placeholder="Password" type="password"
+                                    <input class="form-control password" placeholder="Password" type="password"
                                            th:field="*{password}">
                                 </div>
                             </div>


### PR DESCRIPTION
Cafe24Ssurround 폰트가 비밀번호 기호 표현을 하지 못하여 해당 부분의 폰트를 s-core 폰트로 변경.
Issue Number: #324